### PR TITLE
Organize and partially deglob imports

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,15 +1,15 @@
-//use libc::*;
-use std::ffi::CString;
 
 use failure::Error;
 use bcc_sys::bccapi::*;
+
+use symbol;
+use table::Table;
+use types::MutPointer;
+
+use std::ffi::CString;
 use std::collections::HashMap;
 use std::fs::File;
 use std::os::unix::prelude::*;
-use symbol;
-use table::Table;
-
-use types::*;
 
 // TODO: implement `Drop` for this type
 #[derive(Debug)]

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,8 +1,8 @@
-use std::ffi::CString;
-extern crate bcc_sys;
 use failure::Error;
-use self::bcc_sys::bccapi::*;
+use bcc_sys::bccapi::*;
+
 use std::mem;
+use std::ffi::CString;
 
 pub fn resolve_symbol_path(
     module: &str,

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,11 +1,12 @@
 use libc::size_t;
-extern crate bcc_sys;
 use failure::Error;
-use self::bcc_sys::bccapi::*;
+use bcc_sys::bccapi::*;
+
+use types::{MutPointer, fd_t};
+
 use std::ffi::CStr;
 use std;
 
-use types::*;
 
 #[derive(Clone, Debug)]
 pub struct Table {


### PR DESCRIPTION
This small PR reorganizes the imports in to blocks that clarify where the imports come from. The style that I use is:
```
*external imports*

*imports from this project*

*imports from std*
```

Feel free to reject this PR if you have a style that you prefer.