### PR TITLE
Switch from using raw fds to Files

### DIFF
--- a/examples/strlen.rs
+++ b/examples/strlen.rs
@@ -42,8 +42,8 @@ int count(struct pt_regs *ctx) {
 };
     ";
     let mut module = BPF::new(code)?;
-    let uprobe = module.load_uprobe("count")?;
-    module.attach_uprobe("/lib/x86_64-linux-gnu/libc.so.6", "strlen", uprobe, -1 /* all PIDs */)?;
+    let uprobe_code = module.load_uprobe("count")?;
+    module.attach_uprobe("/lib/x86_64-linux-gnu/libc.so.6", "strlen", uprobe_code, -1 /* all PIDs */)?;
     let table = module.table("counts");
     loop {
         std::thread::sleep(std::time::Duration::from_millis(1000));


### PR DESCRIPTION
Previously we were passing around a lot of raw file descriptors, which wasn't very safe. This switches the API to instead return a `File` from `load_uprobe` so that the file gets closed at the end of the program.

All the files are owned by the `BPF` struct and get dropped when that struct is dropped, which I think is right.