### PR TITLE
refactor: tracepoint

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -195,7 +195,7 @@ pub struct Tracepoint {
 }
 
 impl Tracepoint {
-    fn attach(
+    pub fn attach_tracepoint(
         subsys: &str,
         name: &str,
         file: File,


### PR DESCRIPTION
* patterned after #19 and #20 but for tracepoints
* move tracepoint attach/detach from `BPF` to `Tracepoint`
* `Tracepoint` now implements `Drop` directly
* return Error instead of `unwrap`ing `CString` failures when attaching `Tracepoint`
* remove `Drop` impl for `BPF`, auto-derived trait should be sufficient here