### PR TITLE
docs: add basic library rustdocs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["bpf", "bindings", "bcc"]
 license = "MIT"
 repository = "https://github.com/jvns/rust-bcc"
 readme = "README.md"
-documentation = "https://docs.rs/bcc/0.0.2/bcc/"
+documentation = "https://docs.rs/bcc"
 homepage = "https://github.com/jvns/rust-bcc"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,12 @@
+//! Rust bindings for the BCC compiler collection to enable eBPF instrumentation
+//!
+//! # Goals
+//! * Provide idiomatic Rust bindings for the BCC compiler collection
+//! * Mimic the Python BCC bindings <https://github.com/iovisor/bcc>
+//!
+//! # Examples
+//! * see <https://github.com/jvns/rust-bcc/examples>
+
 pub mod core;
 pub mod symbol;
 pub mod perf;


### PR DESCRIPTION
* add some basic library rustdoc based on the README
* fix the Cargo docs.rs link to not pin docs to 0.0.2